### PR TITLE
add rate limit response for amount of requests

### DIFF
--- a/apps/api/src/__init__.py
+++ b/apps/api/src/__init__.py
@@ -10,7 +10,7 @@ from fastapi.responses import RedirectResponse
 from . import mock as mocks
 from .autobuilder import build_agents
 from .crew import Crew
-from .dependencies import rate_limit, rate_limit_profile, rate_limit_tiered
+from .dependencies import RateLimitResponse, rate_limit, rate_limit_profile, rate_limit_tiered
 from .improver import PromptType, improve_prompt
 from .interfaces import db
 from .models import CrewModel, Message, Session
@@ -69,7 +69,7 @@ def improve(
 
 
 @app.get(
-    "/crew", dependencies=[Depends(rate_limit_profile(limit=4, period_seconds=60))]
+    "/crew"
 )  # change to tiered rate limiter later, its annoying for testing so its currently using profile rate limiter
 async def run_crew(
     id: UUID,
@@ -78,6 +78,7 @@ async def run_crew(
     session_id: UUID | None = None,
     reply: str | None = None,
     mock: bool = False,
+    current_rate_limit: RateLimitResponse = Depends(rate_limit_profile(limit=4, period_seconds=60))
 ) -> dict:
     if reply and not session_id:
         raise HTTPException(
@@ -144,7 +145,7 @@ async def run_crew(
 
     background_tasks.add_task(crew.run, message, messages=cached_messages)
 
-    return {"status": "success", "data": {"session": session.model_dump()}}
+    return {"status": "success", "data": {"session": session.model_dump()}, "rate_limit": current_rate_limit.__dict__()}
 
 
 @app.get(

--- a/apps/api/src/__init__.py
+++ b/apps/api/src/__init__.py
@@ -10,7 +10,12 @@ from fastapi.responses import RedirectResponse
 from . import mock as mocks
 from .autobuilder import build_agents
 from .crew import Crew
-from .dependencies import RateLimitResponse, rate_limit, rate_limit_profile, rate_limit_tiered
+from .dependencies import (
+    RateLimitResponse,
+    rate_limit,
+    rate_limit_profile,
+    rate_limit_tiered,
+)
 from .improver import PromptType, improve_prompt
 from .interfaces import db
 from .models import CrewModel, Message, Session
@@ -78,7 +83,9 @@ async def run_crew(
     session_id: UUID | None = None,
     reply: str | None = None,
     mock: bool = False,
-    current_rate_limit: RateLimitResponse = Depends(rate_limit_profile(limit=4, period_seconds=60))
+    current_rate_limit: RateLimitResponse = Depends(
+        rate_limit_profile(limit=4, period_seconds=60)
+    ),
 ) -> dict:
     if reply and not session_id:
         raise HTTPException(
@@ -145,7 +152,11 @@ async def run_crew(
 
     background_tasks.add_task(crew.run, message, messages=cached_messages)
 
-    return {"status": "success", "data": {"session": session.model_dump()}, "rate_limit": current_rate_limit.__dict__()}
+    return {
+        "status": "success",
+        "data": {"session": session.model_dump()},
+        "rate_limit": current_rate_limit.__dict__(),
+    }
 
 
 @app.get(

--- a/apps/api/src/dependencies/__init__.py
+++ b/apps/api/src/dependencies/__init__.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass
 import logging
 import uuid
+from dataclasses import dataclass
 from typing import Callable, cast
 
 from fastapi import HTTPException
@@ -10,10 +10,11 @@ from src.interfaces.redis_cache import get_redis
 
 logger = logging.getLogger("root")
 
+
 @dataclass
-class RateLimitResponse():
+class RateLimitResponse:
     limit: int
-    current_requests: int 
+    current_requests: int
     time_to_refresh: int
 
     @property
@@ -21,7 +22,12 @@ class RateLimitResponse():
         return self.limit - self.current_requests
 
     def __dict__(self) -> dict:
-        return {"limit": self.limit, "current_requests": self.current_requests, "time_to_refresh": self.time_to_refresh, "remaining_requests": self.remaining_requests}
+        return {
+            "limit": self.limit,
+            "current_requests": self.current_requests,
+            "time_to_refresh": self.time_to_refresh,
+            "remaining_requests": self.remaining_requests,
+        }
 
 
 def _validate_profile_id(profile_id: str) -> str:
@@ -71,6 +77,7 @@ def rate_limit(limit: int, period_seconds: int, endpoint: str) -> Callable:
         if current_requests == 1:
             redis.expire(key, period_seconds)
         return RateLimitResponse(limit, current_requests, cast(int, redis.ttl(key)))
+
     return func
 
 
@@ -103,7 +110,9 @@ def rate_limit_tiered(profile_id: str) -> RateLimitResponse:
     return RateLimitResponse(limit, current_requests, cast(int, redis.ttl(key)))
 
 
-def rate_limit_profile(limit: int, period_seconds: int) -> Callable[[str], RateLimitResponse]:
+def rate_limit_profile(
+    limit: int, period_seconds: int
+) -> Callable[[str], RateLimitResponse]:
     """
     Dependency generator for rate limiting using profile id
 

--- a/apps/api/src/dependencies/__init__.py
+++ b/apps/api/src/dependencies/__init__.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import logging
 import uuid
 from typing import Callable, cast
@@ -8,6 +9,19 @@ from src.interfaces.db import supabase
 from src.interfaces.redis_cache import get_redis
 
 logger = logging.getLogger("root")
+
+@dataclass
+class RateLimitResponse():
+    limit: int
+    current_requests: int 
+    time_to_refresh: int
+
+    @property
+    def remaining_requests(self) -> int:
+        return self.limit - self.current_requests
+
+    def __dict__(self) -> dict:
+        return {"limit": self.limit, "current_requests": self.current_requests, "time_to_refresh": self.time_to_refresh, "remaining_requests": self.remaining_requests}
 
 
 def _validate_profile_id(profile_id: str) -> str:
@@ -47,7 +61,7 @@ def rate_limit(limit: int, period_seconds: int, endpoint: str) -> Callable:
         429: Exceeded the rate limit
     """
 
-    def func() -> None:
+    def func() -> RateLimitResponse:
         redis = get_redis()
         key = f"rate_limit:{endpoint}"
         current_requests = cast(int, redis.incr(key))
@@ -56,11 +70,11 @@ def rate_limit(limit: int, period_seconds: int, endpoint: str) -> Callable:
             raise HTTPException(status_code=429, detail="Rate limit exceeded")
         if current_requests == 1:
             redis.expire(key, period_seconds)
-
+        return RateLimitResponse(limit, current_requests, cast(int, redis.ttl(key)))
     return func
 
 
-def rate_limit_tiered(profile_id: str) -> None:
+def rate_limit_tiered(profile_id: str) -> RateLimitResponse:
     """
     Dependency for rate limiting using the subscription tier of a profile id
 
@@ -71,7 +85,7 @@ def rate_limit_tiered(profile_id: str) -> None:
     """
     redis = get_redis()
     key = f"rate_limit_tiered:{profile_id}"
-    current_requests = redis.incr(key)
+    current_requests = cast(int, redis.incr(key))
 
     tier_id = _validate_profile_id(profile_id)
     tier = supabase.table("tiers").select("period", "limit").eq("id", tier_id).execute()
@@ -86,9 +100,10 @@ def rate_limit_tiered(profile_id: str) -> None:
 
     if current_requests == 1:
         redis.expire(key, period * 3600)
+    return RateLimitResponse(limit, current_requests, cast(int, redis.ttl(key)))
 
 
-def rate_limit_profile(limit: int, period_seconds: int) -> Callable[[str], None]:
+def rate_limit_profile(limit: int, period_seconds: int) -> Callable[[str], RateLimitResponse]:
     """
     Dependency generator for rate limiting using profile id
 
@@ -102,7 +117,7 @@ def rate_limit_profile(limit: int, period_seconds: int) -> Callable[[str], None]
 
     """
 
-    def func(profile_id: str) -> None:
+    def func(profile_id: str) -> RateLimitResponse:
         _ = _validate_profile_id(profile_id)
 
         redis = get_redis()
@@ -113,5 +128,6 @@ def rate_limit_profile(limit: int, period_seconds: int) -> Callable[[str], None]
             raise HTTPException(status_code=429, detail="Rate limit exceeded")
         if current_requests == 1:
             redis.expire(key, period_seconds)
+        return RateLimitResponse(limit, current_requests, cast(int, redis.ttl(key)))
 
     return func


### PR DESCRIPTION
```python
@dataclass
class RateLimitResponse():
    limit: int
    current_requests: int 
    time_to_refresh: int

    @property
    def remaining_requests(self) -> int:
        return self.limit - self.current_requests
```
rate limiter dependencies now return this object and can be returned as part of the request

below is how to get the response object from the dependency:
```diff
diff --git a/apps/api/src/__init__.py b/apps/api/src/__init__.py
index 6c839e9..ce6eb27 100644
--- a/apps/api/src/__init__.py
+++ b/apps/api/src/__init__.py
@@ -69,7 +69,7 @@ def improve(
 
 
 @app.get(
-    "/crew", dependencies=[Depends(rate_limit_profile(limit=4, period_seconds=60))]
+    "/crew"
 )  # change to tiered rate limiter later, its annoying for testing so its currently using profile rate limiter
 async def run_crew(
     id: UUID,
@@ -78,6 +78,7 @@ async def run_crew(
     session_id: UUID | None = None,
     reply: str | None = None,
     mock: bool = False,
+    current_rate_limit: RateLimitResponse = Depends(rate_limit_profile(limit=4, period_seconds=60))
 ) -> dict:
     if reply and not session_id:
         raise HTTPException(
@@ -144,7 +145,7 @@ async def run_crew(
 
     background_tasks.add_task(crew.run, message, messages=cached_messages)
 
-    return {"status": "success", "data": {"session": session.model_dump()}}
+    return {"status": "success", "data": {"session": session.model_dump()}, "rate_limit": current_rate_limit.__dict__()}
 
 
 @app.get(

```

here's what the response body looks like:
```json
{
  "status": "success",
  "data": {
    "session": {
      "id": "b48ddedb-9864-4bdc-9f19-71c2df845b8c",
      "crew_id": "1c11a9bf-748f-482b-9746-6196f136401a",
      "profile_id": "070c1d2e-9d72-4854-a55e-52ade5a42071",
      "created_at": "2024-03-21T11:27:44.755154Z"
    }
  },
  "rate_limit": {
    "limit": 4,
    "current_requests": 1,
    "time_to_refresh": 60,
    "remaining_requests": 3
  }
}
```