### PR TITLE
Change supabase url env name for rest project

### DIFF
--- a/apps/api/src/rest/interfaces/db.py
+++ b/apps/api/src/rest/interfaces/db.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta
 
 load_dotenv()
 
-url: str | None = os.environ.get("SUPABASE_URL")
+url: str | None = os.environ.get("REST_SUPABASE_URL")
 key: str | None = os.environ.get("SUPABASE_ANON_KEY")
 
 if url is None or key is None:


### PR DESCRIPTION
changed it to "REST_SUPABASE_URL" since it had the same name as the aitino url, will add the rest supabase url to env variables on the server