### PR TITLE
Add endpoint for getting all models

### DIFF
--- a/apps/api/src/__init__.py
+++ b/apps/api/src/__init__.py
@@ -18,7 +18,7 @@ from .dependencies import (
 )
 from .improver import PromptType, improve_prompt
 from .interfaces import db
-from .models import Profile
+from .models import Profile, LLMModel
 from .routers import agents, api_key_types, api_keys
 from .routers import auth as auth_router
 from .routers import (
@@ -114,3 +114,8 @@ def auto_build_crew(general_task: str) -> str:
 @app.get("/me")
 def get_profile_from_header(current_user=Depends(get_current_user)) -> Profile:
     return current_user
+
+
+@app.get("/models")
+def get_models() -> list[LLMModel]:
+    return db.get_models()

--- a/apps/api/src/interfaces/db.py
+++ b/apps/api/src/interfaces/db.py
@@ -43,6 +43,7 @@ from src.models import (
     Tool,
     ToolInsertRequest,
     ToolUpdateRequest,
+    LLMModel
 )
 from src.models.tiers import TierGetRequest
 
@@ -867,6 +868,12 @@ def delete_profile(profile_id: UUID) -> Profile:
     supabase: Client = create_client(url, key)
     response = supabase.table("profiles").delete().eq("id", profile_id).execute()
     return Profile(**response.data[0])
+
+
+def get_models():
+    supabase: Client = create_client(url, key)
+    response = supabase.table("models").select("*").execute()
+    return [LLMModel(**data) for data in response.data]
 
 
 if __name__ == "__main__":

--- a/apps/api/src/interfaces/db.py
+++ b/apps/api/src/interfaces/db.py
@@ -870,7 +870,7 @@ def delete_profile(profile_id: UUID) -> Profile:
     return Profile(**response.data[0])
 
 
-def get_models():
+def get_models() -> list[LLMModel]:
     supabase: Client = create_client(url, key)
     response = supabase.table("models").select("*").execute()
     return [LLMModel(**data) for data in response.data]

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -4,6 +4,7 @@ from .agent_model import (
     AgentGetRequest,
     AgentInsertRequest,
     AgentUpdateModel,
+    LLMModel,
 )
 from .api_key import (
     APIKey,
@@ -108,4 +109,5 @@ __all__ = [
     "BillingInsertRequest",
     "BillingUpdateRequest",
     "ValidCrew",
+    "LLMModel",
 ]


### PR DESCRIPTION
returns a list of the id and name of the current llm models, endpoint is currently in the app. Will move it to its own router if more endpoints are needed for interacting with the models table