### PR TITLE
fix: set moch receiver_id as it's faultily required by api

### DIFF
--- a/apps/web/src/routes/app/crews/+page.server.ts
+++ b/apps/web/src/routes/app/crews/+page.server.ts
@@ -53,6 +53,7 @@ export const actions = {
 				body: {
 					profile_id: user.id,
 					...data,
+					receiver_id: '00000000-0000-0000-0000-000000000000',
 					agents: []
 				}
 			})


### PR DESCRIPTION
Set the receiver_id to 000...000 because it's required by the api.