### PR TITLE
fix: remove error toast on agent deletion

### DIFF
--- a/apps/web/src/routes/app/crews/[id]/nodes/node-agent.svelte
+++ b/apps/web/src/routes/app/crews/[id]/nodes/node-agent.svelte
@@ -54,8 +54,6 @@
 
 		<button
 			on:click={() => {
-				toast.error(`Error: Agent ${id} not found, please refresh the page.`);
-
 				deleteAgent();
 			}}
 			aria-label="delete agent"


### PR DESCRIPTION
The error toast that was previously shown when an agent was deleted has been removed. This change simplifies the user experience by not displaying an error message for a successful operation.