### PR TITLE
fix(agent-model): rename 'gpt-3.5-turbo' to 'gpt-35-turbo'

### DIFF
--- a/apps/web/src/lib/schema.ts
+++ b/apps/web/src/lib/schema.ts
@@ -46,7 +46,7 @@ export const agentSchema = z.object({
 	role: z.string().min(1).max(50),
 	tools: z.array(z.any()),
 	system_message: z.string().min(20),
-	model: z.union([z.literal('gpt-4-turbo'), z.literal('gpt-3.5-turbo')], z.literal('gpt-4'))
+	model: z.union([z.literal('gpt-4-turbo'), z.literal('gpt-35-turbo')], z.literal('gpt-4'))
 });
 export type AgentSchema = typeof agentSchema;
 

--- a/apps/web/src/routes/app/agents/CreateForm.svelte
+++ b/apps/web/src/routes/app/agents/CreateForm.svelte
@@ -74,7 +74,7 @@
 					<Select.Group>
 						<Select.Label>Models</Select.Label>
 						<Select.Item value="gpt-4-turbo" label="gpt-4-turbo">gpt-4-turbo</Select.Item>
-						<Select.Item value="gpt-3.5-turbo" label="gpt-3.5-turbo">gpt-3.5-turbo</Select.Item>
+						<Select.Item value="gpt-35-turbo" label="gpt-3.5-turbo">gpt-3.5-turbo</Select.Item>
 					</Select.Group>
 				</Select.Content>
 			</Select.Root>

--- a/apps/web/src/routes/app/agents/[id]/+page.svelte
+++ b/apps/web/src/routes/app/agents/[id]/+page.svelte
@@ -149,7 +149,7 @@
 						<Select.Group>
 							<Select.Label>Models</Select.Label>
 							<Select.Item value="gpt-4-turbo" label="gpt-4-turbo">gpt-4-turbo</Select.Item>
-							<Select.Item value="gpt-3.5-turbo" label="gpt-3.5-turbo">gpt-3.5-turbo</Select.Item>
+							<Select.Item value="gpt-35-turbo" label="gpt-3.5-turbo">gpt-3.5-turbo</Select.Item>
 						</Select.Group>
 					</Select.Content>
 				</Select.Root>

--- a/apps/web/src/routes/app/agents/components/agent-items.svelte
+++ b/apps/web/src/routes/app/agents/components/agent-items.svelte
@@ -45,7 +45,7 @@
 
 	const models = [
 		{ value: 'gpt-4-turbo-preview', label: 'gpt-4-turbo-preview' },
-		{ value: 'gpt-3.5-turbo', label: 'gpt-3.5-turbo' }
+		{ value: 'gpt-35-turbo', label: 'gpt-3.5-turbo' }
 	];
 
 	$: published = isCreate ? $formAgent?.published === 'true' : selectedAgent?.published || false;

--- a/apps/web/src/routes/app/crews/[id]/AgentLibrary.svelte
+++ b/apps/web/src/routes/app/crews/[id]/AgentLibrary.svelte
@@ -115,8 +115,8 @@
 							Published
 						</DropdownMenu.CheckboxItem>
 						<DropdownMenu.CheckboxItem
-							checked={filterModel === 'gpt-3.5-turbo'}
-							on:click={() => updateFilterModel('gpt-3.5-turbo')}
+							checked={filterModel === 'gpt-35-turbo'}
+							on:click={() => updateFilterModel('gpt-35-turbo')}
 						>
 							GPT-3.5-turbo
 						</DropdownMenu.CheckboxItem>


### PR DESCRIPTION
This commit changes the naming convention of the 'gpt-3.5-turbo' model to 'gpt-35-turbo'. This change has been reflected in the schema, creation form, agent page, agent items, and agent library.