### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -18,7 +18,7 @@ python = ">=3.11,<3.13"
 uvicorn = "^0.27.1"
 fastapi = "^0.110.0"
 tenacity = "^8.2.3"
-pyautogen = { extras = ["retrievechat"], version = "^0.2.22" }
+ag2 = { extras = ["retrievechat"], version = "^0.2.22" }
 chromadb = "^0.4.24"
 supabase = "^2.4.0"
 aiohttp = "^3.10.11"


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency package name in the application configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->